### PR TITLE
Create relevant volumes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,4 +16,7 @@ web:
     - '443:443'
   volumes:
     - ./Autolab/courses:/home/app/webapp/courses
+    - ./Autolab/assessmentConfig:/home/app/webapp/assessmentConfig
+    - ./Autolab/courseConfig:/home/app/webapp/courseConfig
+    - ./Autolab/gradebooks:/home/app/webapp/gradebooks
     - ./ssl:/etc/nginx/ssl


### PR DESCRIPTION
Fixes #1.

If these folders don't exist, they're created. This works perfectly with
any of our existing solutions, for example the way we have `courses` as
a symlink on milkshark, while fixing the problems others have been
reporting.